### PR TITLE
Optionally generate ffi.load loading from cpath

### DIFF
--- a/rust-example/src/build.rs
+++ b/rust-example/src/build.rs
@@ -8,6 +8,7 @@ fn main() {
     let output = generator::generate(
         &env::current_dir().unwrap().as_path().join("src/ffi.rs"),
         "rust_example",
+        false,
     );
 
     use std::io::Write;

--- a/rust-unit/src/build.rs
+++ b/rust-unit/src/build.rs
@@ -8,6 +8,7 @@ fn main() {
     let output = generator::generate(
         &env::current_dir().unwrap().as_path().join("src/ffi.rs"),
         "rust_unit",
+        false,
     );
 
     use std::io::Write;


### PR DESCRIPTION
Default behavior of `ffi.load` is to use the system
defined shared library lookup procedure where this change
optionally uses the Lua `package.cpath`