### PR TITLE
Updates to pass clippy with rust 1.39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 # It is not intended for manual editing.
 [[package]]
 name = "c-marshalling"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -29,9 +29,9 @@ dependencies = [
 
 [[package]]
 name = "generator"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
- "parser 0.1.0",
+ "parser 0.2.0",
  "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -48,9 +48,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lua-marshalling"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "c-marshalling 0.1.0",
+ "c-marshalling 0.2.0",
  "derive-lua-marshalling 0.2.0",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -58,7 +58,7 @@ dependencies = [
 
 [[package]]
 name = "parser"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "quote 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.12.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -89,20 +89,20 @@ dependencies = [
 name = "rust-example"
 version = "0.1.0"
 dependencies = [
- "c-marshalling 0.1.0",
- "generator 1.0.0",
+ "c-marshalling 0.2.0",
+ "generator 2.0.0",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "lua-marshalling 0.2.0",
+ "lua-marshalling 0.3.0",
 ]
 
 [[package]]
 name = "rust-unit"
 version = "0.1.0"
 dependencies = [
- "c-marshalling 0.1.0",
- "generator 1.0.0",
+ "c-marshalling 0.2.0",
+ "generator 2.0.0",
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
- "lua-marshalling 0.2.0",
+ "lua-marshalling 0.3.0",
 ]
 
 [[package]]

--- a/c-marshalling/Cargo.toml
+++ b/c-marshalling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "c-marshalling"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Johan Gardell <736172+gardell@users.noreply.github.com>"]
 
 [dependencies]

--- a/c-marshalling/src/lib.rs
+++ b/c-marshalling/src/lib.rs
@@ -66,6 +66,9 @@ pub fn box_into_ptr<R, T: IntoRawConversion<Raw = R>>(value: T) -> Result<*mut T
     value.into_raw().map(Box::new).map(Box::into_raw)
 }
 
+/// # Safety
+///
+/// Only called in an auto-generated context. Should not be called directly.
 pub unsafe fn box_from_ptr<R, T: FromRawConversion<Raw = R>>(raw: *mut T::Raw) -> Result<T, Error> {
     T::from_raw(*Box::from_raw(raw))
 }
@@ -129,7 +132,7 @@ impl<T: PtrAsReference> PtrAsReference for Vec<T> {
 
     unsafe fn raw_as_ref(raw: &Self::Raw) -> Result<Self, Error> {
         ::std::slice::from_raw_parts(raw.ptr, raw.len as usize)
-            .into_iter()
+            .iter()
             .map(|value| T::raw_as_ref(value))
             .collect()
     }

--- a/generator/Cargo.toml
+++ b/generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "generator"
-version = "1.0.0"
+version = "2.0.0"
 authors = ["Johan Gardell <736172+gardell@users.noreply.github.com>"]
 
 [dependencies]

--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -187,6 +187,9 @@ end
                             .unwrap_or_else(::std::ptr::null_mut)
                 }
 
+                /// # Safety
+                ///
+                /// Only called in an auto-generated context. Should not be called directly.
                 #[no_mangle]
                 pub unsafe extern "C" fn __free_lua_bootstrap(bootstrap: *mut ::libc::c_char) {
                     if bootstrap != ::std::ptr::null_mut() {

--- a/lua-marshalling/Cargo.toml
+++ b/lua-marshalling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lua-marshalling"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Johan Gardell <736172+gardell@users.noreply.github.com>"]
 
 [dependencies]

--- a/lua-marshalling/src/lib.rs
+++ b/lua-marshalling/src/lib.rs
@@ -15,17 +15,17 @@ fn is_valid_type_prefix(string: &str) -> bool {
     string.is_empty() || {
         let mut bytes = string.as_bytes().iter();
         (match bytes.next().unwrap() {
-            #[cfg_attr(rustfmt, rustfmt::skip)]
-            | b'a'...b'z'
-            | b'A'...b'Z'
+            #[rustfmt::skip]
+            | b'a'..=b'z'
+            | b'A'..=b'Z'
             | b'_'
             => true,
             _ => false,
         }) && bytes.all(|byte| match *byte {
-            #[cfg_attr(rustfmt, rustfmt::skip)]
-            | b'a'...b'z'
-            | b'A'...b'Z'
-            | b'0'...b'9'
+            #[rustfmt::skip]
+            | b'a'..=b'z'
+            | b'A'..=b'Z'
+            | b'0'..=b'9'
             | b'_'
             => true,
             _ => false,
@@ -158,7 +158,7 @@ pub fn dependency_sorted_type_descriptions<'a>(
                 .find(|&(_, dependencies)| dependencies.dependencies.is_disjoint(&remaining))
                 .unwrap();
             sorted_dependencies.push(dependencies);
-            typ.clone()
+            *typ
         };
         assert!(remaining.remove(&typ));
     }
@@ -587,9 +587,26 @@ end"#,
     };
 }
 
-use libc::{
-    int16_t, int32_t, int64_t, int8_t, size_t, ssize_t, uint16_t, uint32_t, uint64_t, uint8_t,
-};
+#[allow(non_camel_case_types)]
+type int16_t = i16;
+#[allow(non_camel_case_types)]
+type int32_t = i32;
+#[allow(non_camel_case_types)]
+type int64_t = i64;
+#[allow(non_camel_case_types)]
+type int8_t = i8;
+#[allow(non_camel_case_types)]
+type uint16_t = u16;
+#[allow(non_camel_case_types)]
+type uint32_t = u32;
+#[allow(non_camel_case_types)]
+type uint64_t = u64;
+#[allow(non_camel_case_types)]
+type uint8_t = u8;
+#[allow(non_camel_case_types)]
+type size_t = usize;
+#[allow(non_camel_case_types)]
+type ssize_t = isize;
 
 #[allow(non_camel_case_types)]
 type float = f32;

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parser"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Johan Gardell <736172+gardell@users.noreply.github.com>"]
 
 [dependencies]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -88,13 +88,13 @@ pub fn functions(items: &[::syn::Item]) -> Vec<Function> {
                         ),
                     };
                     Argument {
-                        ident: name.clone(),
+                        ident: *name,
                         typ,
                     }
                 })
                 .collect();
             Function {
-                ident: ident.clone(),
+                ident: *ident,
                 args,
                 ret: match *output {
                     ::syn::ReturnType::Default => quote! { () },
@@ -129,6 +129,9 @@ pub fn function_declarations(functions: &[Function], uses: &[::quote::Tokens]) -
         let ret = &function.ret;
         let ident = &function.ident;
         quote! {
+                /// # Safety
+                ///
+                /// Only called in an auto-generated context. Should not be called directly.
                 #[no_mangle]
                 pub unsafe extern "C" fn #ident(
                         #(#argument_declaration,)*
@@ -141,6 +144,9 @@ pub fn function_declarations(functions: &[Function], uses: &[::quote::Tokens]) -
                     }).unwrap_or(Ok(2)).unwrap_or(1)
                 }
 
+                /// # Safety
+                ///
+                /// Only called in an auto-generated context. Should not be called directly.
                 #[no_mangle]
                 pub unsafe extern "C" fn #gc_ident(
                         output: <#ret as ::c_marshalling::IntoRawConversion>::Ptr) -> u32 {


### PR DESCRIPTION
Note: Intent is to squish into a single commit once the version changes are set.

I don't know that I've actually addressed everything that would offend Clippy—only that for the project where we use these crates, it no longer holds its nose.

Feel free to change or ask for changes on the Safety verbiage. I considered just `#[allow(...)]`ing it directly, but I thought that would make unnecessary trouble for someone who has a `forbid` against `clippy::missing_safety_doc`. (Note: Is the Safety verbiage accurate, or are those functions not even visible where they could be incorrectly called by non-generated code?)

Also feel free to make changes to the version bumps—especially for some of the syntax updates that will increase the required Rust version.

Caveat:
There could be other pieces of generate-able code with Clippy issues, but it doesn't end up being generated by the project where we use this.