### PR TITLE
fix: resolve array_into_iter compatibility lint

### DIFF
--- a/generator/src/lib.rs
+++ b/generator/src/lib.rs
@@ -139,7 +139,7 @@ end
                 pub extern "C" fn __lua_bootstrap() -> *mut ::libc::c_char {
                     let unique_types: ::lua_marshalling::Dependencies =
                         [ #(#extern_lua_unique_types)* ]
-                            .into_iter()
+                            .iter()
                             .flat_map(|value| value.into_iter()
                                 .map(|(k, v)| (k.clone(), v.clone())))
                             .collect();


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/66145 for discussion of the
lint, which may become an error in a future version of Rust.

We ran into this as an issue when we upgraded to 1.41 (since we generally build with `RUSTFLAGS="--deny warnings"`).